### PR TITLE
Implement TLS Destructors

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -6,6 +6,8 @@ use std::collections::BTreeMap;
 use std::ptr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use crate::thread_keys;
+
 pub mod attr;
 
 /// The main thread's pthread ID
@@ -86,6 +88,8 @@ pub unsafe extern "C" fn pthread_create(
         if let Some(mut pthread) = thread_map.get_mut(&thread_id) {
             pthread.is_finished = true;
             pthread.result.0 = result;
+
+            thread_keys::run_local_destructors();
 
             if pthread.is_detached {
                 // libctru will call threadFree once this thread dies


### PR DESCRIPTION
Closes #19 

This PR aims to completely implement TLS destructors.

<h1>WIP Issues</h1>

While the small changes I made seem to correctly yield control over to the [`run_dtors`](https://github.com/rust-lang/rust/blob/4a03f14b099bf19f0124872b3f6d99ef00db7902/library/std/src/sys_common/thread_local_dtor.rs#L39) function in `std`, some internal issues compromise the tls system.

The first `Key` (which is always the `THREAD_INFO` key) has a properly set destructor which runs to completion without any problems. However, in my testing environment, the `Key` right after has a corrupted pointer for its destructor (and sometimes, value).

Correctly run dtor (seen via gdb):
![image](https://user-images.githubusercontent.com/55318903/233706101-52f0ae62-a484-4b65-b6a5-5ac2bf26fad2.png)

Incorrectly run dtor:
![image](https://user-images.githubusercontent.com/55318903/233706332-2771cb91-f33a-492f-b1e8-9ae82eab0fa3.png)

After a couple of re-runs, I've noticed that the `__malloc_av` function (with some sort of offset) appears often as the dtor and that the `ptr` and `dtor` value are often equal, though this behaviour is most likely the result of some other problem.

It's been hard getting to understand this issue, since it appears within `std`'s TLS system. Is there, perhaps, something wrong with our TLS var creation?

---
I may not be able to help with the whole toolchain in the following month, so I'm trying to put out as much info I gather as possible, even when it's not much 😅.